### PR TITLE
Added more config options for max itemstack and speed of transfer

### DIFF
--- a/src/main/java/net/gnomecraft/ductwork/base/DuctworkBlockEntity.java
+++ b/src/main/java/net/gnomecraft/ductwork/base/DuctworkBlockEntity.java
@@ -1,6 +1,7 @@
 package net.gnomecraft.ductwork.base;
 
 import net.gnomecraft.cooldowncoordinator.CoordinatedCooldown;
+import net.gnomecraft.ductwork.Ductwork;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.block.entity.LockableContainerBlockEntity;
@@ -16,7 +17,7 @@ import net.minecraft.util.math.BlockPos;
 import java.util.Iterator;
 
 public abstract class DuctworkBlockEntity extends LockableContainerBlockEntity implements CoordinatedCooldown, Inventory {
-    public final static int defaultCooldown = 8;  // 4 redstone ticks, just like vanilla
+    public final static int defaultCooldown = Ductwork.getConfig().itemTransferCooldown;  // 4 redstone ticks, just like vanilla
     protected DefaultedList<ItemStack> inventory;
     protected long lastTickTime;
     protected int transferCooldown;

--- a/src/main/java/net/gnomecraft/ductwork/collector/CollectorEntity.java
+++ b/src/main/java/net/gnomecraft/ductwork/collector/CollectorEntity.java
@@ -147,7 +147,7 @@ public class CollectorEntity extends DuctworkBlockEntity implements Hopper {
         if (sourceStorage != null && targetStorage != null) {
             boolean targetEmpty = CooldownCoordinator.isStorageEmpty(targetStorage);
 
-            if (StorageUtil.move(sourceStorage, targetStorage, variant -> true, 1, null) > 0) {
+            if (StorageUtil.move(sourceStorage, targetStorage, variant -> true, Ductwork.getConfig().maxItemStackCollector, null) > 0) {
                 if (targetEmpty) {
                     CooldownCoordinator.notify(targetEntity);
                 }
@@ -184,7 +184,7 @@ public class CollectorEntity extends DuctworkBlockEntity implements Hopper {
 
         // Try to pull from any discovered storage or inventory...
         if (sourceStorage != null && targetStorage != null) {
-            boolean result =  (StorageUtil.move(sourceStorage, targetStorage, variant -> true, 1, null) > 0);
+            boolean result =  (StorageUtil.move(sourceStorage, targetStorage, variant -> true, Ductwork.getConfig().maxItemStackCollector, null) > 0);
             BlockEntity sourceEntity = world.getBlockEntity(pos.offset(intake));
             if (sourceEntity != null) {
                 sourceEntity.markDirty();

--- a/src/main/java/net/gnomecraft/ductwork/config/DuctworkConfig.java
+++ b/src/main/java/net/gnomecraft/ductwork/config/DuctworkConfig.java
@@ -24,4 +24,26 @@ public class DuctworkConfig implements ConfigData {
     @ConfigEntry.Gui.PrefixText
     @ConfigEntry.Gui.Tooltip
     public boolean cheaper = false;
+
+    @Comment("Cooldown for item transfer (8 = 4 redstone ticks, just like vanilla)")
+    @ConfigEntry.Gui.PrefixText
+    @ConfigEntry.Gui.Tooltip
+    public int itemTransferCooldown = 8;
+
+    @Comment("Max number of itemstacks that can be moved simultaneously for duct")
+    @ConfigEntry.Gui.PrefixText
+    @ConfigEntry.Gui.Tooltip
+    public int maxItemStackDuct = 1;
+
+    @Comment("Max number of itemstacks that can be moved simultaneously for collector")
+    @ConfigEntry.Gui.PrefixText
+    @ConfigEntry.Gui.Tooltip
+    public int maxItemStackCollector = 1;
+
+    @Comment("Max number of itemstacks that can be moved simultaneously for damper")
+    @ConfigEntry.Gui.PrefixText
+    @ConfigEntry.Gui.Tooltip
+    public int maxItemStackDamper = 1;
+
+
 }

--- a/src/main/java/net/gnomecraft/ductwork/damper/DamperEntity.java
+++ b/src/main/java/net/gnomecraft/ductwork/damper/DamperEntity.java
@@ -70,7 +70,7 @@ public class DamperEntity extends DuctworkBlockEntity implements SidedInventory 
         if (sourceStorage != null && targetStorage != null) {
             boolean targetEmpty = CooldownCoordinator.isStorageEmpty(targetStorage);
 
-            if (StorageUtil.move(sourceStorage, targetStorage, variant -> true, 1, null) > 0) {
+            if (StorageUtil.move(sourceStorage, targetStorage, variant -> true, Ductwork.getConfig().maxItemStackDamper, null) > 0) {
                 if (targetEmpty) {
                     CooldownCoordinator.notify(targetEntity);
                 }

--- a/src/main/java/net/gnomecraft/ductwork/duct/DuctEntity.java
+++ b/src/main/java/net/gnomecraft/ductwork/duct/DuctEntity.java
@@ -69,7 +69,7 @@ public class DuctEntity extends DuctworkBlockEntity {
         if (sourceStorage != null && targetStorage != null) {
             boolean targetEmpty = CooldownCoordinator.isStorageEmpty(targetStorage);
 
-            if (StorageUtil.move(sourceStorage, targetStorage, variant -> true, 1, null) > 0) {
+            if (StorageUtil.move(sourceStorage, targetStorage, variant -> true, Ductwork.getConfig().maxItemStackDuct, null) > 0) {
                 if (targetEmpty) {
                     CooldownCoordinator.notify(targetEntity);
                 }

--- a/src/main/resources/assets/ductwork/lang/en_us.json
+++ b/src/main/resources/assets/ductwork/lang/en_us.json
@@ -20,5 +20,22 @@
 
   "text.autoconfig.ductwork.option.cheaper":   "Cheaper Ductwork Blocks?",
   "text.autoconfig.ductwork.option.cheaper.@PrefixText": "Use less Iron in Ductwork recipes?\nConvenient for iron farm nerfing modpacks.",
-  "text.autoconfig.ductwork.option.cheaper.@Tooltip": "Server overrides client."
+  "text.autoconfig.ductwork.option.cheaper.@Tooltip": "Server overrides client.",
+
+  "text.autoconfig.ductwork.option.itemTransferCooldown":   "Cooldown for item transfer (8 = 4 redstone ticks, just like vanilla)",
+  "text.autoconfig.ductwork.option.itemTransferCooldown.@PrefixText": "Configurable speed in duct blocks.",
+  "text.autoconfig.ductwork.option.itemTransferCooldown.@Tooltip": "Server overrides client.",
+
+  "text.autoconfig.ductwork.option.maxItemStackDuct":   "Max number of simultaneously itemstacks for duct.",
+  "text.autoconfig.ductwork.option.maxItemStackDuct.@PrefixText": "Number of items that can be transferred simultaneously.",
+  "text.autoconfig.ductwork.option.maxItemStackDuct.@Tooltip": "Server overrides client.",
+
+  "text.autoconfig.ductwork.option.maxItemStackCollector":   "Max number of simultaneously itemstacks for collector",
+  "text.autoconfig.ductwork.option.maxItemStackCollector.@PrefixText": "Number of items that can be transferred simultaneously.",
+  "text.autoconfig.ductwork.option.maxItemStackCollector.@Tooltip": "Server overrides client.",
+
+  "text.autoconfig.ductwork.option.maxItemStackDamper":   "Max number of simultaneously itemstacks for damper",
+  "text.autoconfig.ductwork.option.maxItemStackDamper.@PrefixText": "Number of items that can be transferred simultaneously.",
+  "text.autoconfig.ductwork.option.maxItemStackDamper.@Tooltip": "Server overrides client."
+
 }


### PR DESCRIPTION
Translation for French must be done.

You can now adjust the transfer speed of items in ticks.

Additionally, you have the ability to configure the maximum item stack amounts that will be transferred in ducts, collectors, and dampers.

Values can be modified in the configuration, with default values reflecting the coding settings from before.